### PR TITLE
feat: Optimize genpy serialization/deserialize path for large messages [AT-2258]

### DIFF
--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -476,10 +476,14 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
                 yield 'if type(%s) in [list, tuple]:' % var
                 yield INDENT+pack2("'<I%sB'%length", 'length, *%s' % var)
                 yield 'else:'
-                # When the payload is already bytes, write the length prefix and
-                # the payload separately so the (potentially large) payload goes
-                # straight to the buffer. Packing it via struct would first copy
-                # the whole payload into a temporary 4+length buffer.
+                # Write the length prefix and the payload separately so the
+                # (potentially large) payload goes straight to the buffer.
+                # Packing it via struct would first copy the whole payload into
+                # a temporary 4+length buffer. Using memoryview(...).nbytes for
+                # the length lets any C-contiguous buffer (bytes, bytearray, or
+                # a numpy array) be written directly without a .tobytes() copy;
+                # for bytes it is identical to len().
+                yield INDENT+'length = memoryview(%s).nbytes' % var
                 yield INDENT+int32_pack('length')
                 yield INDENT+'buff.write(%s)' % var
             else:

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -476,7 +476,12 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
                 yield 'if type(%s) in [list, tuple]:' % var
                 yield INDENT+pack2("'<I%sB'%length", 'length, *%s' % var)
                 yield 'else:'
-                yield INDENT+pack2("'<I%ss'%length", 'length, %s' % var)
+                # When the payload is already bytes, write the length prefix and
+                # the payload separately so the (potentially large) payload goes
+                # straight to the buffer. Packing it via struct would first copy
+                # the whole payload into a temporary 4+length buffer.
+                yield INDENT+int32_pack('length')
+                yield INDENT+'buff.write(%s)' % var
             else:
                 yield 'if type(%s) in [list, tuple]:' % var
                 yield INDENT+pack('%sB' % array_len, '*%s' % var)

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -954,6 +954,8 @@ def msg_generator(msg_context, spec, search_path):
     for y in serialize_fn_generator(msg_context, spec):
         yield '    ' + y
     yield """
+  _SUPPORTS_LOANED_DESERIALIZE = True
+
   def deserialize(self, bytes_: bytes, loaned: bool = False) -> \'%s\':
     \"\"\"
     unpack serialized message in str into this message instance

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -502,11 +502,25 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
         yield 'start = end'
         if array_len is not None:
             yield 'end += %s' % array_len
-            yield '%s = bytes_[start:end]' % var
+            if base_type in ['uint8', 'char']:
+                # `loaned` is a runtime parameter of deserialize(): when set, the
+                # byte-array payload is borrowed as a zero-copy memoryview of the
+                # input buffer instead of being copied out with bytes_[start:end].
+                yield 'if loaned:'
+                yield INDENT + '%s = memoryview(bytes_)[start:end]' % var
+                yield 'else:'
+                yield INDENT + '%s = bytes_[start:end]' % var
+            else:
+                yield '%s = bytes_[start:end]' % var
         else:
             yield 'end += length'
             if base_type in ['uint8', 'char']:
-                yield '%s = bytes_[start:end]' % (var)
+                # See the fixed-length branch above: `loaned` selects a zero-copy
+                # memoryview view over the input buffer at runtime.
+                yield 'if loaned:'
+                yield INDENT + '%s = memoryview(bytes_)[start:end]' % var
+                yield 'else:'
+                yield INDENT + '%s = bytes_[start:end]' % var
             else:
                 yield 'if python3:'
                 yield INDENT+"%s = bytes_[start:end].decode('utf-8', 'rosmsg')" % (var)  # If messages are python3-decode back to unicode
@@ -940,10 +954,15 @@ def msg_generator(msg_context, spec, search_path):
     for y in serialize_fn_generator(msg_context, spec):
         yield '    ' + y
     yield """
-  def deserialize(self, bytes_: bytes) -> \'%s\':
+  def deserialize(self, bytes_: bytes, loaned: bool = False) -> \'%s\':
     \"\"\"
     unpack serialized message in str into this message instance
     :param bytes_: byte array of serialized message, ``bytes``
+    :param loaned: if True, variable- and fixed-length uint8[]/char[] fields are
+      borrowed as zero-copy ``memoryview`` slices of *bytes_* instead of being
+      copied. The returned message then aliases *bytes_*, so the caller must keep
+      it alive and unmutated for the lifetime of the message and any arrays
+      derived from those fields.
     \"\"\"""" %  spec.short_name
     for y in deserialize_fn_generator(msg_context, spec):
         yield '    ' + y
@@ -959,11 +978,13 @@ def msg_generator(msg_context, spec, search_path):
     for y in serialize_fn_generator(msg_context, spec, is_numpy=True):
         yield '    ' + y
     yield """
-  def deserialize_numpy(self, str, numpy):
+  def deserialize_numpy(self, str, numpy, loaned=False):
     \"\"\"
     unpack serialized message in str into this message instance using numpy for array types
     :param str: byte array of serialized message, ``str``
     :param numpy: numpy python module
+    :param loaned: if True, uint8[]/char[] fields are borrowed as zero-copy
+      ``memoryview`` slices of the input buffer instead of being copied.
     \"\"\""""
     for y in deserialize_fn_generator(msg_context, spec, is_numpy=True):
         yield '    ' + y

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -476,13 +476,6 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
                 yield 'if type(%s) in [list, tuple]:' % var
                 yield INDENT+pack2("'<I%sB'%length", 'length, *%s' % var)
                 yield 'else:'
-                # Write the length prefix and the payload separately so the
-                # (potentially large) payload goes straight to the buffer.
-                # Packing it via struct would first copy the whole payload into
-                # a temporary 4+length buffer. Using memoryview(...).nbytes for
-                # the length lets any C-contiguous buffer (bytes, bytearray, or
-                # a numpy array) be written directly without a .tobytes() copy;
-                # for bytes it is identical to len().
                 yield INDENT+'length = memoryview(%s).nbytes' % var
                 yield INDENT+int32_pack('length')
                 yield INDENT+'buff.write(%s)' % var

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -496,9 +496,6 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
         if array_len is not None:
             yield 'end += %s' % array_len
             if base_type in ['uint8', 'char']:
-                # `loaned` is a runtime parameter of deserialize(): when set, the
-                # byte-array payload is borrowed as a zero-copy memoryview of the
-                # input buffer instead of being copied out with bytes_[start:end].
                 yield 'if loaned:'
                 yield INDENT + '%s = memoryview(bytes_)[start:end]' % var
                 yield 'else:'

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -483,7 +483,7 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
                 yield 'if type(%s) in [list, tuple]:' % var
                 yield INDENT+pack('%sB' % array_len, '*%s' % var)
                 yield 'else:'
-                yield INDENT+pack('%ss' % array_len, var)
+                yield INDENT+'buff.write(%s)' % var
         else:
             # FIXME: for py3k, this needs to be w/ encode(), but this interferes with actual byte data
             yield 'if python3 or type(%s) == unicode:' % (var)

--- a/src/genpy/generator.py
+++ b/src/genpy/generator.py
@@ -505,8 +505,6 @@ def string_serializer_generator(package, type_, name, serialize):  # noqa: D401
         else:
             yield 'end += length'
             if base_type in ['uint8', 'char']:
-                # See the fixed-length branch above: `loaned` selects a zero-copy
-                # memoryview view over the input buffer at runtime.
                 yield 'if loaned:'
                 yield INDENT + '%s = memoryview(bytes_)[start:end]' % var
                 yield 'else:'

--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -298,13 +298,13 @@ def check_type(field_name, field_type, field_val):
         # use index to generate error if '[' not present
         base_type = field_type[:field_type.index('[')]
 
-        if type(field_val) in (bytes, str):
+        if type(field_val) in (bytes, str, bytearray, memoryview):
             if base_type not in ['char', 'uint8']:
                 raise SerializationError('field %s must be a list or tuple type. Only uint8[] can be a string' % field_name)
             else:
-                # It's a string so its already in byte format and we
-                # don't need to check the individual bytes in the
-                # string.
+                # It's already in byte/buffer format (bytes, bytearray or a
+                # memoryview, e.g. from deserialize(..., loaned=True)) so we
+                # don't need to check the individual bytes.
                 return
 
         if not type(field_val) in [list, tuple]:

--- a/test/files/array/uint8_fixed_deser.txt
+++ b/test/files/array/uint8_fixed_deser.txt
@@ -1,3 +1,6 @@
 start = end
 end += 8
-data = bytes_[start:end]
+if loaned:
+  data = memoryview(bytes_)[start:end]
+else:
+  data = bytes_[start:end]

--- a/test/files/array/uint8_fixed_deser_np.txt
+++ b/test/files/array/uint8_fixed_deser_np.txt
@@ -1,3 +1,6 @@
 start = end
 end += 8
-data = bytes_[start:end]
+if loaned:
+  data = memoryview(bytes_)[start:end]
+else:
+  data = bytes_[start:end]

--- a/test/files/array/uint8_fixed_ser.txt
+++ b/test/files/array/uint8_fixed_ser.txt
@@ -2,4 +2,4 @@
 if type(data) in [list, tuple]:
   buff.write(_get_struct_8B().pack(*data))
 else:
-  buff.write(_get_struct_8s().pack(data))
+  buff.write(data)

--- a/test/files/array/uint8_fixed_ser_np.txt
+++ b/test/files/array/uint8_fixed_ser_np.txt
@@ -2,4 +2,4 @@
 if type(data) in [list, tuple]:
   buff.write(_get_struct_8B().pack(*data))
 else:
-  buff.write(_get_struct_8s().pack(data))
+  buff.write(data)

--- a/test/files/array/uint8_varlen_deser.txt
+++ b/test/files/array/uint8_varlen_deser.txt
@@ -3,4 +3,7 @@ end += 4
 (length,) = _struct_I.unpack(bytes_[start:end])
 start = end
 end += length
-data = bytes_[start:end]
+if loaned:
+  data = memoryview(bytes_)[start:end]
+else:
+  data = bytes_[start:end]

--- a/test/files/array/uint8_varlen_deser_np.txt
+++ b/test/files/array/uint8_varlen_deser_np.txt
@@ -3,4 +3,7 @@ end += 4
 (length,) = _struct_I.unpack(bytes_[start:end])
 start = end
 end += length
-data = bytes_[start:end]
+if loaned:
+  data = memoryview(bytes_)[start:end]
+else:
+  data = bytes_[start:end]

--- a/test/files/array/uint8_varlen_ser.txt
+++ b/test/files/array/uint8_varlen_ser.txt
@@ -3,4 +3,6 @@ length = len(data)
 if type(data) in [list, tuple]:
   buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
 else:
-  buff.write(struct.Struct('<I%ss'%length).pack(length, data))
+  length = memoryview(data).nbytes
+  buff.write(_struct_I.pack(length))
+  buff.write(data)

--- a/test/files/array/uint8_varlen_ser_np.txt
+++ b/test/files/array/uint8_varlen_ser_np.txt
@@ -3,4 +3,6 @@ length = len(data)
 if type(data) in [list, tuple]:
   buff.write(struct.Struct('<I%sB'%length).pack(length, *data))
 else:
-  buff.write(struct.Struct('<I%ss'%length).pack(length, data))
+  length = memoryview(data).nbytes
+  buff.write(_struct_I.pack(length))
+  buff.write(data)

--- a/test/test_genpy_dynamic.py
+++ b/test/test_genpy_dynamic.py
@@ -155,6 +155,67 @@ def _test_ser_deser(m_instance1, m_instance2):
     assert m_instance1 == m_instance2
 
 
+def test_loaned_deserialize_reserialize():
+    # This test validates the serialize -> deserialize(loaned=True) -> re-serialize
+    # round-trip for fixed-length uint8[N] and variable-length uint8[] fields.
+    # deserialize(loaned=True) borrows both fields as zero-copy memoryview slices;
+    # re-serialize must write those buffers directly (buff.write) rather than via
+    # struct's 's' format, which rejects memoryview. It also checks that serialize
+    # accepts bytearray/memoryview inputs and that _check_types() does not reject
+    # loaned memoryview fields.
+    from genpy.dynamic import generate_dynamic
+
+    msgs = generate_dynamic('gd_msgs/ByteArrays', 'uint8[16] fixed\nuint8[] varlen\n')
+    cls = msgs['gd_msgs/ByteArrays']
+    assert getattr(cls, '_SUPPORTS_LOANED_DESERIALIZE', False)
+
+    fixed_payload = bytes(range(16))
+    varlen_payload = bytes(range(10, 20))
+    expected = cls()
+    expected.fixed = fixed_payload
+    expected.varlen = varlen_payload
+
+    src = cls()
+    src.fixed = fixed_payload
+    src.varlen = varlen_payload
+    buff = StringIO()
+    src.serialize(buff)
+    wire = buff.getvalue()
+
+    # loaned deserialize yields zero-copy memoryview slices
+    loaned = cls().deserialize(wire, loaned=True)
+    assert type(loaned.fixed) is memoryview
+    assert type(loaned.varlen) is memoryview
+    assert bytes(loaned.fixed) == fixed_payload
+    assert bytes(loaned.varlen) == varlen_payload
+    loaned._check_types()
+
+    # re-serialize loaned message (used to crash on fixed uint8[N])
+    buff2 = StringIO()
+    loaned.serialize(buff2)
+    assert buff2.getvalue() == wire
+
+    # non-loaned deserialize should still round-trip
+    copied = cls().deserialize(wire)
+    assert copied == expected
+
+    # serialize accepts buffer-like payloads directly
+    for payload in (bytearray(fixed_payload), memoryview(fixed_payload)):
+        m = cls()
+        m.fixed = payload
+        m.varlen = varlen_payload
+        buff3 = StringIO()
+        m.serialize(buff3)
+        assert buff3.getvalue() == wire
+    for payload in (bytearray(varlen_payload), memoryview(varlen_payload)):
+        m = cls()
+        m.fixed = fixed_payload
+        m.varlen = payload
+        buff4 = StringIO()
+        m.serialize(buff4)
+        assert buff4.getvalue() == wire
+
+
 def test_serialize_exception():
     import genpy
     from genpy.dynamic import generate_dynamic

--- a/test/test_genpy_generator.py
+++ b/test/test_genpy_generator.py
@@ -336,7 +336,9 @@ buff.write(struct.Struct('<I%ss'%length).pack(length, var_name))""" == val, val
 if type(b_name) in [list, tuple]:
   buff.write(struct.Struct('<I%sB'%length).pack(length, *b_name))
 else:
-  buff.write(struct.Struct('<I%ss'%length).pack(length, b_name))""" == '\n'.join(g)
+  length = memoryview(b_name).nbytes
+  buff.write(_struct_I.pack(length))
+  buff.write(b_name)""" == '\n'.join(g)
 
     # Test Deserializers
     val = """start = end


### PR DESCRIPTION
## What Change
Removes one unneeded copy from serialization and one one copy during deserializaiton of byte arrays.

### Serialize: write byte-array payloads without copies

Two changes to the bytes (non-list) serialize branch for variable-length `uint8[]`/`char[]` fields:

- **Split the length prefix from the payload.** Write the 4-byte length and the payload as separate `buff.write` calls instead of `struct.Struct('<I%ss' % length).pack(length, payload)`, which first copies the whole payload into a temporary `4+length` buffer.

- **Compute length from `memoryview(x).nbytes` and write `x` directly.** For `bytes` it is unchanged (`nbytes == len`); it also corrects the length for multi-dimensional arrays, where `len(x)` is only the first dimension.


### Deserialize: opt-in zero-copy via `loaned=True`

`deserialize()` (and `deserialize_numpy()`) gain a runtime `loaned: bool = False` parameter. For each `uint8[]`/`char[]` field, both branches are emitted into the generated code and selected at runtime:

```python
if loaned:
    self.data = memoryview(bytes_)[start:end]   # zero-copy view over the input
else:
    self.data = bytes_[start:end]               # copy (unchanged default)
```

- The default `loaned=False` preserves existing copy semantics, so all current `msg.deserialize(data)` callers are unaffected.
- With `loaned=True` the returned message **aliases** the input buffer, avoiding duplication of large payloads (e.g. image/depth buffers) on the receive side. 

## Test

- [x] Test that serialized messages are byte identical.