### PR TITLE
fix: Broken generator tests after typed-ros-msgs changes []

### DIFF
--- a/test/files/array/bool_fixed_deser.txt
+++ b/test/files/array/bool_fixed_deser.txt
@@ -1,4 +1,4 @@
 start = end
 end += 3
-data = _get_struct_3B().unpack(str[start:end])
+data = _get_struct_3B().unpack(bytes_[start:end])
 data = list(map(bool, data))

--- a/test/files/array/bool_varlen_deser.txt
+++ b/test/files/array/bool_varlen_deser.txt
@@ -1,9 +1,9 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 pattern = '<%sB'%length
 start = end
 s = struct.Struct(pattern)
 end += s.size
-data = s.unpack(str[start:end])
+data = s.unpack(bytes_[start:end])
 data = list(map(bool, data))

--- a/test/files/array/int16_fixed_deser.txt
+++ b/test/files/array/int16_fixed_deser.txt
@@ -1,3 +1,3 @@
 start = end
 end += 20
-data = _get_struct_10h().unpack(str[start:end])
+data = _get_struct_10h().unpack(bytes_[start:end])

--- a/test/files/array/int16_fixed_deser_np.txt
+++ b/test/files/array/int16_fixed_deser_np.txt
@@ -1,3 +1,3 @@
 start = end
 end += 20
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=10)
+data = numpy.frombuffer(bytes_[start:end], dtype=numpy.int16, count=10)

--- a/test/files/array/int16_varlen_deser.txt
+++ b/test/files/array/int16_varlen_deser.txt
@@ -1,8 +1,8 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 pattern = '<%sh'%length
 start = end
 s = struct.Struct(pattern)
 end += s.size
-data = s.unpack(str[start:end])
+data = s.unpack(bytes_[start:end])

--- a/test/files/array/int16_varlen_deser_np.txt
+++ b/test/files/array/int16_varlen_deser_np.txt
@@ -1,8 +1,8 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 pattern = '<%sh'%length
 start = end
 s = struct.Struct(pattern)
 end += s.size
-data = numpy.frombuffer(str[start:end], dtype=numpy.int16, count=length)
+data = numpy.frombuffer(bytes_[start:end], dtype=numpy.int16, count=length)

--- a/test/files/array/object_fixed_deser.txt
+++ b/test/files/array/object_fixed_deser.txt
@@ -3,5 +3,5 @@ for i in range(0, 3):
   val0 = foo_msg_Object()
   start = end
   end += 4
-  (val0.data,) = _get_struct_i().unpack(str[start:end])
+  (val0.data,) = _get_struct_i().unpack(bytes_[start:end])
   data.append(val0)

--- a/test/files/array/object_varlen_deser.txt
+++ b/test/files/array/object_varlen_deser.txt
@@ -1,10 +1,10 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 data = []
 for i in range(0, length):
   val0 = foo_msg_Object()
   start = end
   end += 4
-  (val0.data,) = _get_struct_i().unpack(str[start:end])
+  (val0.data,) = _get_struct_i().unpack(bytes_[start:end])
   data.append(val0)

--- a/test/files/array/string_fixed_deser.txt
+++ b/test/files/array/string_fixed_deser.txt
@@ -2,11 +2,11 @@ data = []
 for i in range(0, 2):
   start = end
   end += 4
-  (length,) = _struct_I.unpack(str[start:end])
+  (length,) = _struct_I.unpack(bytes_[start:end])
   start = end
   end += length
   if python3:
-    val0 = str[start:end].decode('utf-8', 'rosmsg')
+    val0 = bytes_[start:end].decode('utf-8', 'rosmsg')
   else:
-    val0 = str[start:end]
+    val0 = bytes_[start:end]
   data.append(val0)

--- a/test/files/array/string_varlen_deser.txt
+++ b/test/files/array/string_varlen_deser.txt
@@ -1,15 +1,15 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 data = []
 for i in range(0, length):
   start = end
   end += 4
-  (length,) = _struct_I.unpack(str[start:end])
+  (length,) = _struct_I.unpack(bytes_[start:end])
   start = end
   end += length
   if python3:
-    val0 = str[start:end].decode('utf-8', 'rosmsg')
+    val0 = bytes_[start:end].decode('utf-8', 'rosmsg')
   else:
-    val0 = str[start:end]
+    val0 = bytes_[start:end]
   data.append(val0)

--- a/test/files/array/uint8_fixed_deser.txt
+++ b/test/files/array/uint8_fixed_deser.txt
@@ -1,3 +1,3 @@
 start = end
 end += 8
-data = str[start:end]
+data = bytes_[start:end]

--- a/test/files/array/uint8_fixed_deser_np.txt
+++ b/test/files/array/uint8_fixed_deser_np.txt
@@ -1,3 +1,3 @@
 start = end
 end += 8
-data = str[start:end]
+data = bytes_[start:end]

--- a/test/files/array/uint8_varlen_deser.txt
+++ b/test/files/array/uint8_varlen_deser.txt
@@ -1,6 +1,6 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 start = end
 end += length
-data = str[start:end]
+data = bytes_[start:end]

--- a/test/files/array/uint8_varlen_deser_np.txt
+++ b/test/files/array/uint8_varlen_deser_np.txt
@@ -1,6 +1,6 @@
 start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 start = end
 end += length
-data = str[start:end]
+data = bytes_[start:end]

--- a/test/test_genpy_generator.py
+++ b/test/test_genpy_generator.py
@@ -52,7 +52,7 @@ def test_Simple():
     val = genpy.generator.get_special('time').import_str
     assert 'import genpy' == val, val
     assert 'import genpy' == genpy.generator.get_special('duration').import_str
-    assert 'import std_msgs.msg' == genpy.generator.get_special('Header').import_str
+    assert 'from std_msgs.msg._Header import Header as std_msgs_msg_Header' == genpy.generator.get_special('Header').import_str
 
     assert 'genpy.Time()' == genpy.generator.get_special('time').constructor
     assert 'genpy.Duration()' == genpy.generator.get_special('duration').constructor
@@ -237,20 +237,20 @@ def test_compute_import():
     #  'from ci2_msgs.msg._Base2 import Base2 as ci2_msgs_msg_Base2',
     #  'from ci_msgs.msg._Base import Base as ci_msgs_msg_Base',
     # 'from ci3_msgs.msg._Base3 import Base3 as ci3_msgs_msg_Base3']
-    assert {'import ci4_msgs.msg',
-            'import ci3_msgs.msg',
-            'import ci2_msgs.msg', 
-            'import ci_msgs.msg'} == set(genpy.generator.compute_import(msg_context, 'foo', 'ci4_msgs/Base4'))
-    assert {'import ci4_msgs.msg',
-            'import ci3_msgs.msg',
-            'import ci2_msgs.msg',
-            'import ci_msgs.msg'} == set(genpy.generator.compute_import(msg_context, 'ci4_msgs', 'ci4_msgs/Base4'))
+    assert {'from ci4_msgs.msg._Base4 import Base4 as ci4_msgs_msg_Base4',
+            'from ci3_msgs.msg._Base3 import Base3 as ci3_msgs_msg_Base3',
+            'from ci2_msgs.msg._Base2 import Base2 as ci2_msgs_msg_Base2',
+            'from ci_msgs.msg._Base import Base as ci_msgs_msg_Base'} == set(genpy.generator.compute_import(msg_context, 'foo', 'ci4_msgs/Base4'))
+    assert {'from ci4_msgs.msg._Base4 import Base4 as ci4_msgs_msg_Base4',
+            'from ci3_msgs.msg._Base3 import Base3 as ci3_msgs_msg_Base3',
+            'from ci2_msgs.msg._Base2 import Base2 as ci2_msgs_msg_Base2',
+            'from ci_msgs.msg._Base import Base as ci_msgs_msg_Base'} == set(genpy.generator.compute_import(msg_context, 'ci4_msgs', 'ci4_msgs/Base4'))
 
-    assert ['import ci4_msgs.msg'] == genpy.generator.compute_import(msg_context, 'foo', 'ci4_msgs/Base')
-    assert ['import ci4_msgs.msg'] == genpy.generator.compute_import(msg_context, 'ci4_msgs', 'ci4_msgs/Base')
-    assert ['import ci4_msgs.msg'] == genpy.generator.compute_import(msg_context, 'ci4_msgs', 'Base')
+    assert ['from ci4_msgs.msg._Base import Base as ci4_msgs_msg_Base'] == genpy.generator.compute_import(msg_context, 'foo', 'ci4_msgs/Base')
+    assert ['from ci4_msgs.msg._Base import Base as ci4_msgs_msg_Base'] == genpy.generator.compute_import(msg_context, 'ci4_msgs', 'ci4_msgs/Base')
+    assert ['from ci4_msgs.msg._Base import Base as ci4_msgs_msg_Base'] == genpy.generator.compute_import(msg_context, 'ci4_msgs', 'Base')
 
-    assert ['import ci5_msgs.msg', 'import genpy'] == genpy.generator.compute_import(msg_context, 'foo', 'ci5_msgs/Base')
+    assert ['from ci5_msgs.msg._Base import Base as ci5_msgs_msg_Base', 'import genpy'] == genpy.generator.compute_import(msg_context, 'foo', 'ci5_msgs/Base')
 
 
 def test_get_registered_ex():
@@ -309,7 +309,7 @@ def test_len_serializer_generator():
     # Test Deserializers
     val = """start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])"""
+(length,) = _struct_I.unpack(bytes_[start:end])"""
     # string serializer and array serializer are identical
     g = genpy.generator.len_serializer_generator('foo', True, False)
     assert val == '\n'.join(g)
@@ -341,13 +341,13 @@ else:
     # Test Deserializers
     val = """start = end
 end += 4
-(length,) = _struct_I.unpack(str[start:end])
+(length,) = _struct_I.unpack(bytes_[start:end])
 start = end
 end += length
 if python3:
-  var_name = str[start:end].decode('utf-8', 'rosmsg')
+  var_name = bytes_[start:end].decode('utf-8', 'rosmsg')
 else:
-  var_name = str[start:end]"""
+  var_name = bytes_[start:end]"""
     # string serializer and array serializer are identical
     g = genpy.generator.string_serializer_generator('foo', 'string', 'var_name', False)
     assert val == '\n'.join(g)


### PR DESCRIPTION
## Summary
Fixes prexisting errors in the tests.

- Updates `test/test_genpy_generator.py` expectations and the `test/files/array` + `test/files/complex` fixtures to match the current generator output on `pickle/typed-ros-msgs`.
- Deserializers now read from `bytes_` instead of `str`.
- Imports use the `from pkg.msg._Type import Type as pkg_msg_Type` form (including the `Header` special import string).

## Test plan
- [x] @neilmacintyre  reviewed AI generated code.
- [x] `PYTHONPATH=src python -m pytest test/test_genpy_generator.py` 