### PR TITLE
fix: Fix dynamic message generation for bag file playback []

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>genpy</name>
-  <version>0.7.17</version>
+  <version>0.7.18</version>
   <description>Python ROS message and service generators.</description>
   <maintainer email="mabel@openrobotics.org">Mabel Zhang</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>genpy</name>
-  <version>0.7.16</version>
+  <version>0.7.17</version>
   <description>Python ROS message and service generators.</description>
   <maintainer email="mabel@openrobotics.org">Mabel Zhang</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     packages=['genpy'],
     package_dir={'': 'src'},
     requires=['genmsg'],
-    version='0.7.17'
+    version='0.7.18'
 )

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ setup(
     packages=['genpy'],
     package_dir={'': 'src'},
     requires=['genmsg'],
-    version='0.7.16'
+    version='0.7.17'
 )

--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -40,6 +40,7 @@ except ImportError:
     from io import StringIO  # Python 3.x
 
 import atexit
+import importlib
 import os
 import re
 import shutil
@@ -47,6 +48,7 @@ import sys
 import tempfile
 
 import genmsg
+import genmsg.gentools
 import genmsg.msg_loader
 from genmsg import MsgContext, MsgGenerationException
 
@@ -81,14 +83,19 @@ def _gen_dyn_name(pkg, base_type):
     return '_%s__%s' % (pkg, base_type)
 
 
-def _gen_dyn_modify_references(py_text, current_type, types):
+def _gen_dyn_modify_references(py_text, current_type, types, matched=()):
     """
     Modify the generated code to rewrite names such that the code can safely co-exist with messages of the same name.
 
     :param py_text: genmsg_py-generated Python source code, ``str``
+    :param matched: types whose installed class is md5-identical to the bag
+      definition; their aliased imports are kept so references bind to the
+      installed class, ``collection of str``
     :returns: updated text, ``str``
     """
     for t in types:
+        if t in matched:
+            continue
         pkg, base_type = genmsg.package_resource_name(t)
         gen_name = _gen_dyn_name(pkg, base_type)
         alias = '%s_msg_%s' % (pkg, base_type)
@@ -106,22 +113,53 @@ def _gen_dyn_modify_references(py_text, current_type, types):
     py_text = py_text.replace('class %s(' % base_type, 'class %s(' % gen_name)
     # - super() references for __init__
     py_text = py_text.replace('super(%s,' % base_type, 'super(%s,' % gen_name)
-    # std_msgs/Header also has to be rewritten to be a local reference
-    py_text = py_text.replace('std_msgs.msg._Header.Header', _gen_dyn_name('std_msgs', 'Header'))
+    # std_msgs/Header constructor references use a dotted path the aliased
+    # import does not bind, so rewrite them either to the kept alias (md5
+    # match) or to the local dynamically-generated class
+    if 'std_msgs/Header' in matched:
+        py_text = py_text.replace('std_msgs.msg._Header.Header', 'std_msgs_msg_Header')
+    else:
+        py_text = py_text.replace('std_msgs.msg._Header.Header', _gen_dyn_name('std_msgs', 'Header'))
     return py_text
 
 
-def generate_dynamic(core_type, msg_cat):
+def _installed_class_if_md5_match(msg_context, msg_type, spec):
     """
-    Dynamically generate message classes from msg_cat .msg text gendeps dump.
+    Return the installed message class for msg_type if its md5 matches spec.
 
-    This method modifies sys.path to include a temp file directory.
-    :param core_type str: top-level ROS message type of concatenated .msg text
-    :param msg_cat str: concatenation of full message text (output of gendeps --cat)
+    A matching md5 proves the installed definition (including all nested
+    types) is byte-identical to the definition embedded in the bag, so the
+    installed class can be used directly. This preserves class identity with
+    the rest of the process (isinstance checks, C++ bindings such as tf2).
+
+    :returns: installed class, or None if not importable or definitions differ
+    """
+    pkg, base_type = genmsg.package_resource_name(msg_type)
+    try:
+        mod = importlib.import_module('%s.msg._%s' % (pkg, base_type))
+        cls = getattr(mod, base_type)
+    except Exception:
+        return None
+    try:
+        if getattr(cls, '_md5sum', None) == genmsg.gentools.compute_md5(msg_context, spec):
+            return cls
+    except Exception:
+        return None
+    return None
+
+
+def _generate_dynamic_source(core_type, msg_cat):
+    """
+    Build the rewritten dynamic module source for msg_cat .msg text.
+
+    Types whose installed class is md5-identical to the bag definition are not
+    generated; references to them bind to the installed class instead.
+
+    :returns: module source, specs by type, installed classes by matched type,
+      ``(str, dict, dict)``
     :raises: MsgGenerationException If dep_msg is improperly formatted
     """
     msg_context = MsgContext.create_default()
-    core_pkg, core_base_type = genmsg.package_resource_name(core_type)
 
     # REP 100: pretty gross hack to deal with the fact that we moved
     # Header. Header is 'special' because it can be used w/o a package
@@ -150,18 +188,43 @@ def generate_dynamic(core_type, msg_cat):
     for t, spec in specs.items():
         msg_context.register(t, spec)
 
+    # installed classes that provably match the bag definition are used as-is
+    matched = {}
+    for t, spec in specs.items():
+        cls = _installed_class_if_md5_match(msg_context, t, spec)
+        if cls is not None:
+            matched[t] = cls
+
     # process actual MsgSpecs: we accumulate them into a single file,
     # rewriting the generated text as needed
     buff = StringIO()
     for t, spec in specs.items():
-        pkg, s_type = genmsg.package_resource_name(t)
+        if t in matched:
+            continue
         # dynamically generate python message code
         for line in msg_generator(msg_context, spec, search_path):
-            line = _gen_dyn_modify_references(line, t, list(specs.keys()))
+            line = _gen_dyn_modify_references(line, t, list(specs.keys()), matched)
             buff.write(line + '\n')
     full_text = buff.getvalue()
     # Defer annotation evaluation: dependent types may be defined later in this module.
     full_text = 'from __future__ import annotations\n' + full_text
+    return full_text, specs, matched
+
+
+def generate_dynamic(core_type, msg_cat):
+    """
+    Dynamically generate message classes from msg_cat .msg text gendeps dump.
+
+    This method modifies sys.path to include a temp file directory.
+    :param core_type str: top-level ROS message type of concatenated .msg text
+    :param msg_cat str: concatenation of full message text (output of gendeps --cat)
+    :raises: MsgGenerationException If dep_msg is improperly formatted
+    """
+    full_text, specs, matched = _generate_dynamic_source(core_type, msg_cat)
+
+    # every definition matches an installed class: nothing to generate
+    if len(matched) == len(specs):
+        return dict(matched)
 
     # Create a temporary directory
     tmp_dir = tempfile.mkdtemp(prefix='genpy_')
@@ -191,6 +254,11 @@ def generate_dynamic(core_type, msg_cat):
     # finally, retrieve the message classes from the dynamic module
     messages = {}
     for t in specs.keys():
+        if t in matched:
+            # installed class is md5-identical to the bag definition; use it
+            # directly so class identity is preserved (isinstance, tf2, ...)
+            messages[t] = matched[t]
+            continue
         pkg, s_type = genmsg.package_resource_name(t)
         try:
             messages[t] = getattr(mod, _gen_dyn_name(pkg, s_type))

--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -91,14 +91,14 @@ def _gen_dyn_modify_references(py_text, current_type, types):
     for t in types:
         pkg, base_type = genmsg.package_resource_name(t)
         gen_name = _gen_dyn_name(pkg, base_type)
+        alias = '%s_msg_%s' % (pkg, base_type)
 
-        # Several things we have to rewrite:
-        # - remove any import statements
-        py_text = py_text.replace('import %s.msg' % pkg, '')
-        # - rewrite any references to class
-        if '%s.msg.%s' % (pkg, base_type) in py_text:
-            # only call expensive re.sub if the class name is in the string
-            py_text = re.sub(r'(?<!\w)%s\.msg\.%s(?!\w)' % (pkg, base_type), gen_name, py_text)
+        # Drop imports that would otherwise load the INSTALLED definition
+        py_text = py_text.replace(
+            'from %s.msg._%s import %s as %s' % (pkg, base_type, base_type, alias), '')
+        # Rewrite aliased references to the local dynamically-generated class
+        if alias in py_text:
+            py_text = re.sub(r'(?<!\w)%s(?!\w)' % re.escape(alias), gen_name, py_text)
 
     pkg, base_type = genmsg.package_resource_name(current_type)
     gen_name = _gen_dyn_name(pkg, base_type)
@@ -160,6 +160,8 @@ def generate_dynamic(core_type, msg_cat):
             line = _gen_dyn_modify_references(line, t, list(specs.keys()))
             buff.write(line + '\n')
     full_text = buff.getvalue()
+    # Defer annotation evaluation: dependent types may be defined later in this module.
+    full_text = 'from __future__ import annotations\n' + full_text
 
     # Create a temporary directory
     tmp_dir = tempfile.mkdtemp(prefix='genpy_')

--- a/test/test_genpy_dynamic.py
+++ b/test/test_genpy_dynamic.py
@@ -155,38 +155,17 @@ def _test_ser_deser(m_instance1, m_instance2):
     assert m_instance1 == m_instance2
 
 
-def _build_dynamic_source(core_type, msg_cat):
-    """Build rewritten dynamic module source without importing it."""
-    from io import StringIO as TextIO
-
-    from genmsg import MsgContext
-    import genmsg.msg_loader
-    from genpy.dynamic import _generate_dynamic_specs, _gen_dyn_modify_references
-    from genpy.generator import msg_generator
-
-    msg_context = MsgContext.create_default()
-    msg_cat = msg_cat.replace('roslib/Header', 'std_msgs/Header')
-    splits = msg_cat.split('\n' + '=' * 80 + '\n')
-    core_msg = splits[0]
-    deps_msgs = splits[1:]
-    specs = {core_type: genmsg.msg_loader.load_msg_from_string(msg_context, core_msg, core_type)}
-    for dep_msg in deps_msgs:
-        dep_type, dep_spec = _generate_dynamic_specs(msg_context, specs, dep_msg)
-        specs[dep_type] = dep_spec
-    msg_context = genmsg.msg_loader.MsgContext.create_default()
-    for t, spec in specs.items():
-        msg_context.register(t, spec)
-    buff = TextIO()
-    for t, spec in specs.items():
-        for line in msg_generator(msg_context, spec, {}):
-            buff.write(_gen_dyn_modify_references(line, t, list(specs.keys())) + '\n')
-    return 'from __future__ import annotations\n' + buff.getvalue()
+HEADER_DEF = """uint32 seq
+time stamp
+string frame_id
+"""
 
 
 def test_dynamic_generated_source_has_no_installed_imports():
     # Regression test for bag playback: dependent types embedded in the bag
-    # must not import installed packages from PYTHONPATH.
-    from genpy.dynamic import _gen_dyn_modify_references
+    # that do not match an installed definition must not import installed
+    # packages from PYTHONPATH.
+    from genpy.dynamic import _gen_dyn_modify_references, _generate_dynamic_source
 
     types = ['gd_msgs/MoveArmState', 'probot_msgs/JointState', 'std_msgs/Header']
     import_line = 'from probot_msgs.msg._JointState import JointState as probot_msgs_msg_JointState'
@@ -198,27 +177,91 @@ def test_dynamic_generated_source_has_no_installed_imports():
     assert 'probot_msgs_msg_JointState' not in rewritten_ctor
     assert '_probot_msgs__JointState()' in rewritten_ctor
 
-    msg_cat = """Header header
+    msg_cat = """string name
 probot_msgs/JointState[] configuration
-
-================================================================================
-MSG: std_msgs/Header
-uint32 seq
-time stamp
-string frame_id
 
 ================================================================================
 MSG: probot_msgs/JointState
 string name
 float64 position
 """
-    source = _build_dynamic_source('gd_msgs/MoveArmState', msg_cat)
+    source, specs, matched = _generate_dynamic_source('gd_msgs/MoveArmState', msg_cat)
+    assert matched == {}  # neither package is installed
     assert 'from probot_msgs.msg._' not in source
-    assert 'from std_msgs.msg._' not in source
     assert 'probot_msgs_msg_JointState' not in source
-    assert 'std_msgs_msg_Header' not in source
     assert '_probot_msgs__JointState' in source
+
+
+def test_dynamic_uses_installed_class_when_md5_matches():
+    # A bag definition identical to the installed one (md5 match) must yield
+    # the installed class itself, preserving isinstance/type identity for
+    # consumers such as tf2's C++ bindings.
+    import pytest
+    std_msgs = pytest.importorskip('std_msgs.msg')
+    from genpy.dynamic import generate_dynamic
+
+    msgs = generate_dynamic('std_msgs/Header', HEADER_DEF)
+    assert msgs['std_msgs/Header'] is std_msgs.Header
+
+
+def test_dynamic_mixed_matched_and_generated_types():
+    # Unknown/drifted types are generated from the bag definition while
+    # md5-matching dependencies bind to the installed class.
+    import pytest
+    std_msgs = pytest.importorskip('std_msgs.msg')
+    from genpy.dynamic import _generate_dynamic_source, generate_dynamic
+
+    msg_cat = """Header header
+float64 position
+
+================================================================================
+MSG: std_msgs/Header
+""" + HEADER_DEF
+
+    source, specs, matched = _generate_dynamic_source('gd_msgs/JointState', msg_cat)
+    assert set(matched) == {'std_msgs/Header'}
+    assert 'from std_msgs.msg._Header import Header as std_msgs_msg_Header' in source
+    assert '_std_msgs__Header' not in source
+
+    msgs = generate_dynamic('gd_msgs/JointState', msg_cat)
+    assert msgs['std_msgs/Header'] is std_msgs.Header
+    m = msgs['gd_msgs/JointState']()
+    assert isinstance(m.header, std_msgs.Header)
+    m.position = 1.5
+    m2 = msgs['gd_msgs/JointState']()
+    _test_ser_deser(m, m2)
+    assert isinstance(m2.header, std_msgs.Header)
+
+
+def test_dynamic_drifted_header_stays_dynamic():
+    # A std_msgs/Header definition that differs from the installed one (md5
+    # mismatch) must be generated from the bag definition, not the installed
+    # class.
+    import pytest
+    std_msgs = pytest.importorskip('std_msgs.msg')
+    from genpy.dynamic import _generate_dynamic_source, generate_dynamic
+
+    drifted_header = """uint32 seq
+time stamp
+string frame_id
+string extra_field
+"""
+    msg_cat = """Header header
+float64 position
+
+================================================================================
+MSG: std_msgs/Header
+""" + drifted_header
+
+    source, specs, matched = _generate_dynamic_source('gd_msgs/JointState', msg_cat)
+    assert matched == {}
     assert '_std_msgs__Header' in source
+
+    msgs = generate_dynamic('gd_msgs/JointState', msg_cat)
+    assert msgs['std_msgs/Header'] is not std_msgs.Header
+    m = msgs['gd_msgs/JointState']()
+    assert not isinstance(m.header, std_msgs.Header)
+    assert hasattr(m.header, 'extra_field')
 
 
 def test_serialize_exception():

--- a/test/test_genpy_dynamic.py
+++ b/test/test_genpy_dynamic.py
@@ -155,6 +155,72 @@ def _test_ser_deser(m_instance1, m_instance2):
     assert m_instance1 == m_instance2
 
 
+def _build_dynamic_source(core_type, msg_cat):
+    """Build rewritten dynamic module source without importing it."""
+    from io import StringIO as TextIO
+
+    from genmsg import MsgContext
+    import genmsg.msg_loader
+    from genpy.dynamic import _generate_dynamic_specs, _gen_dyn_modify_references
+    from genpy.generator import msg_generator
+
+    msg_context = MsgContext.create_default()
+    msg_cat = msg_cat.replace('roslib/Header', 'std_msgs/Header')
+    splits = msg_cat.split('\n' + '=' * 80 + '\n')
+    core_msg = splits[0]
+    deps_msgs = splits[1:]
+    specs = {core_type: genmsg.msg_loader.load_msg_from_string(msg_context, core_msg, core_type)}
+    for dep_msg in deps_msgs:
+        dep_type, dep_spec = _generate_dynamic_specs(msg_context, specs, dep_msg)
+        specs[dep_type] = dep_spec
+    msg_context = genmsg.msg_loader.MsgContext.create_default()
+    for t, spec in specs.items():
+        msg_context.register(t, spec)
+    buff = TextIO()
+    for t, spec in specs.items():
+        for line in msg_generator(msg_context, spec, {}):
+            buff.write(_gen_dyn_modify_references(line, t, list(specs.keys())) + '\n')
+    return 'from __future__ import annotations\n' + buff.getvalue()
+
+
+def test_dynamic_generated_source_has_no_installed_imports():
+    # Regression test for bag playback: dependent types embedded in the bag
+    # must not import installed packages from PYTHONPATH.
+    from genpy.dynamic import _gen_dyn_modify_references
+
+    types = ['gd_msgs/MoveArmState', 'probot_msgs/JointState', 'std_msgs/Header']
+    import_line = 'from probot_msgs.msg._JointState import JointState as probot_msgs_msg_JointState'
+    ctor_line = '        val1 = probot_msgs_msg_JointState()'
+
+    assert _gen_dyn_modify_references(import_line, 'gd_msgs/MoveArmState', types).strip() == ''
+    rewritten_ctor = _gen_dyn_modify_references(ctor_line, 'gd_msgs/MoveArmState', types)
+    assert 'probot_msgs.msg._JointState' not in rewritten_ctor
+    assert 'probot_msgs_msg_JointState' not in rewritten_ctor
+    assert '_probot_msgs__JointState()' in rewritten_ctor
+
+    msg_cat = """Header header
+probot_msgs/JointState[] configuration
+
+================================================================================
+MSG: std_msgs/Header
+uint32 seq
+time stamp
+string frame_id
+
+================================================================================
+MSG: probot_msgs/JointState
+string name
+float64 position
+"""
+    source = _build_dynamic_source('gd_msgs/MoveArmState', msg_cat)
+    assert 'from probot_msgs.msg._' not in source
+    assert 'from std_msgs.msg._' not in source
+    assert 'probot_msgs_msg_JointState' not in source
+    assert 'std_msgs_msg_Header' not in source
+    assert '_probot_msgs__JointState' in source
+    assert '_std_msgs__Header' in source
+
+
 def test_serialize_exception():
     import genpy
     from genpy.dynamic import generate_dynamic


### PR DESCRIPTION
## Summary
When I introduced types into the message definitions, I changed the import format in the static generator to avoid circular imports. The dynamic message rewriter in dynamic.py (used to construct message classes from definitions embedded in bag files) was never updated for that new format, so bag playback imported types from PYTHONPATH instead of the bag. After this PR merges, bag files can again be deserialized using the definitions stored in the bag, even when installed message definitions differ or the package is not present.

## AI Summary
## Context
After the typed-ros-msgs import refactor ([#2](https://github.com/Pickle-Robot/genpy/pull/2)), the dynamic message rewriter in `dynamic.py` was never updated:

- [54332c5](https://github.com/Pickle-Robot/genpy/commit/54332c51c14b01ba453cf1b5cae340bbb1fece1e) — switched from `from pkg import msg as pkg_msg` to per-type submodule imports (`from pkg.msg._Type import Type`)
- [175823c](https://github.com/Pickle-Robot/genpy/commit/175823c980e252027f6bf8de5b152e5068809810) — added `as pkg_msg_Type` aliases to avoid cross-package name collisions

The rewriter still expected the old `import pkg.msg` / `pkg.msg.Type` format, so bag playback imported message types from PYTHONPATH instead of using definitions embedded in the bag.

## Before / after (generated code excerpt)

**Before (broken):** imports and references still pointed at installed packages on PYTHONPATH

```python
from probot_msgs.msg._JointState import JointState as probot_msgs_msg_JointState
from std_msgs.msg._Header import Header as std_msgs_msg_Header

class MoveArmState(genpy.Message):
  def __init__(self, header: std_msgs_msg_Header = None,
    configuration: List[probot_msgs_msg_JointState] = None):
    ...
    self.header: std_msgs_msg_Header = std_msgs_msg_Header()
    ...
    val1 = probot_msgs_msg_JointState()
```

**After (fixed):** imports removed; all references use locally generated classes from the bag definition

```python
from __future__ import annotations

class _gd_msgs__MoveArmState(genpy.Message):
  def __init__(self, header: _std_msgs__Header = None,
    configuration: List[_probot_msgs__JointState] = None):
    ...
    self.header: _std_msgs__Header = _std_msgs__Header()
    ...
    val1 = _probot_msgs__JointState()
```

## Test plan
- [x] `PYTHONPATH=src python3 -m pytest test/test_genpy_dynamic.py`
- [x] `test_dynamic_generated_source_has_no_installed_imports` asserts rewritten source has no `from pkg.msg._` imports and uses `_pkg__Type` local classes
- [x] `test_generate_dynamic` probot_msgs integration case (#1183) still passes end-to-end
